### PR TITLE
refactor: host_03 페이지 전체적으로 리팩토링

### DIFF
--- a/src/components/albumDetail/AlbumDetailFooter.tsx
+++ b/src/components/albumDetail/AlbumDetailFooter.tsx
@@ -40,20 +40,16 @@ const AlbumDetailFooter = () => {
   const handleOpenMessage = () => {
     startTransition(() => {
       if (messageData?.data.content) {
-        setShouldFetch(false);
-        setMessageCheck((prev) => ({
-          ...prev,
-          isIconCheck: false,
-        }));
         remove();
       } else {
-        setShouldFetch(true);
-        setMessageCheck((prev) => ({
-          ...prev,
-          isIconCheck: true,
-        }));
         refetch();
       }
+
+      setShouldFetch((prev) => !prev);
+      setMessageCheck((prev) => ({
+        ...prev,
+        isIconCheck: !prev.isIconCheck,
+      }));
     });
   };
 

--- a/src/components/albumDetail/AlbumDetailImage.tsx
+++ b/src/components/albumDetail/AlbumDetailImage.tsx
@@ -46,6 +46,7 @@ const AlbumDeatilImage = () => {
         className="mySwiper"
         initialSlide={activeSlider}
         onSlideChange={handleActiveAlbumSave}
+        onSlidesLengthChange={handleActiveAlbumSave}
       >
         {albumDatas?.pages
           ?.flatMap((page: any) => page.data.content)

--- a/src/components/albumDetail/AlbumDetailImage.tsx
+++ b/src/components/albumDetail/AlbumDetailImage.tsx
@@ -13,14 +13,19 @@ import { activeSliderStore } from '../../stores/activeSliderStore';
 import { albumDetailStore } from '../../stores/albumDetailStore';
 import { messageStore } from '../../stores/messageStore';
 import useInfinityAlbum from '../../hooks/useInfinityAlbum';
+import useIntersectionObserver from '../../hooks/useInfinityObserver';
 
 const AlbumDeatilImage = () => {
   const accessToken = useAtomValue(accessTokenStore);
-  const { data: albumDetailData } = useInfinityAlbum(accessToken!);
+  const { data: albumDetailData, fetchNextPage, hasNextPage } = useInfinityAlbum(accessToken!);
   const [thumsSwiper, setThumbsSwiper] = useState<any>(null);
   const activeSlider = useAtomValue(activeSliderStore);
   const setAlbumDetails = useSetAtom(albumDetailStore);
   const setIsActive = useSetAtom(messageStore);
+  const { setTarget } = useIntersectionObserver({
+    hasNextPage,
+    fetchNextPage,
+  });
 
   const handleActiveAlbumSave = (swiper: any) => {
     const currentImage: any = albumDetailData?.pages.filter((_: any, index: number) => index === swiper.activeIndex);
@@ -64,9 +69,10 @@ const AlbumDeatilImage = () => {
         className="mySwiper2"
         initialSlide={activeSlider}
       >
-        {albumDetailData?.pages.map((album: any) => (
+        {albumDetailData?.pages.map((album: any, index: number) => (
           <SwiperSlide key={album.image_Id}>
             <img src={album.resizeUrl} alt={album.originName} />
+            {albumDetailData.pages.length - 3 === index && <div ref={setTarget} />}
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/albumDetail/AlbumDetailImage.tsx
+++ b/src/components/albumDetail/AlbumDetailImage.tsx
@@ -5,9 +5,11 @@ import './swiperCustom.css';
 import { Navigation, Thumbs } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useAtomValue, useSetAtom } from 'jotai';
+import type { SwiperClass } from 'swiper/react';
 import { useState } from 'react';
 import * as S from './AlbumDetail.styled';
 
+import { Album } from '../../types/album';
 import { accessTokenStore } from '../../stores/accessToken';
 import { activeSliderStore } from '../../stores/activeSliderStore';
 import { albumDetailStore } from '../../stores/albumDetailStore';
@@ -17,23 +19,25 @@ import useIntersectionObserver from '../../hooks/useInfinityObserver';
 
 const AlbumDeatilImage = () => {
   const accessToken = useAtomValue(accessTokenStore);
-  const { data: albumDetailData, fetchNextPage, hasNextPage } = useInfinityAlbum(accessToken!);
-  const [thumsSwiper, setThumbsSwiper] = useState<any>(null);
+  const [thumsSwiper, setThumbsSwiper] = useState<SwiperClass | null>(null);
   const activeSlider = useAtomValue(activeSliderStore);
   const setAlbumDetails = useSetAtom(albumDetailStore);
   const setIsActive = useSetAtom(messageStore);
+  const { data: albumDetailData, fetchNextPage, hasNextPage } = useInfinityAlbum(accessToken!);
   const { setTarget } = useIntersectionObserver({
     hasNextPage,
     fetchNextPage,
   });
 
-  const handleActiveAlbumSave = (swiper: any) => {
-    const currentImage: any = albumDetailData?.pages.filter((_: any, index: number) => index === swiper.activeIndex);
+  const handleActiveAlbumSave = (swiper: SwiperClass) => {
+    const currentImage = albumDetailData?.pages.filter(
+      (_: any, index: number) => index === swiper.activeIndex,
+    )[0] as any as Album;
 
-    setAlbumDetails({ ...currentImage[0], activeIndex: swiper.activeIndex });
+    setAlbumDetails({ ...currentImage, activeIndex: swiper.activeIndex });
     setIsActive((prev) => ({
       ...prev,
-      isMessageOpen: currentImage[0]?.contentCheck,
+      isMessageOpen: currentImage?.contentCheck,
       isSwiperCheck: prev.isSwiperCheck + 1,
     }));
   };
@@ -50,9 +54,9 @@ const AlbumDeatilImage = () => {
         onSlideChange={handleActiveAlbumSave}
         onSlidesLengthChange={handleActiveAlbumSave}
       >
-        {albumDetailData?.pages?.map((album: any) => (
+        {albumDetailData?.pages.map((album: any) => (
           <SwiperSlide key={album.image_Id}>
-            <img src={album.accessUrl} alt={album.originName} />
+            <img src={album.accessUrl} alt={album.originName} loading="lazy" />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/albumDetail/AlbumDetailImage.tsx
+++ b/src/components/albumDetail/AlbumDetailImage.tsx
@@ -5,28 +5,25 @@ import './swiperCustom.css';
 import { Navigation, Thumbs } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import * as S from './AlbumDetail.styled';
 
-import type { Album } from '../../types/album';
-import { MAIN_ALBUM_KEY } from '../../api/album';
+import { accessTokenStore } from '../../stores/accessToken';
 import { activeSliderStore } from '../../stores/activeSliderStore';
 import { albumDetailStore } from '../../stores/albumDetailStore';
 import { messageStore } from '../../stores/messageStore';
+import useInfinityAlbum from '../../hooks/useInfinityAlbum';
 
 const AlbumDeatilImage = () => {
-  const queryClient = useQueryClient();
-  const albumDatas = queryClient.getQueryData<any>(MAIN_ALBUM_KEY);
+  const accessToken = useAtomValue(accessTokenStore);
+  const { data: albumDetailData } = useInfinityAlbum(accessToken!);
   const [thumsSwiper, setThumbsSwiper] = useState<any>(null);
   const activeSlider = useAtomValue(activeSliderStore);
   const setAlbumDetails = useSetAtom(albumDetailStore);
   const setIsActive = useSetAtom(messageStore);
 
   const handleActiveAlbumSave = (swiper: any) => {
-    const currentImage = albumDatas?.pages
-      .flatMap((page: any) => page.data.content)
-      .filter((_: any, index: number) => index === swiper.activeIndex);
+    const currentImage: any = albumDetailData?.pages.filter((_: any, index: number) => index === swiper.activeIndex);
 
     setAlbumDetails({ ...currentImage[0], activeIndex: swiper.activeIndex });
     setIsActive((prev) => ({
@@ -48,13 +45,11 @@ const AlbumDeatilImage = () => {
         onSlideChange={handleActiveAlbumSave}
         onSlidesLengthChange={handleActiveAlbumSave}
       >
-        {albumDatas?.pages
-          ?.flatMap((page: any) => page.data.content)
-          .map((album: Album) => (
-            <SwiperSlide key={album.image_Id}>
-              <img src={album.accessUrl} alt={album.originName} />
-            </SwiperSlide>
-          ))}
+        {albumDetailData?.pages?.map((album: any) => (
+          <SwiperSlide key={album.image_Id}>
+            <img src={album.accessUrl} alt={album.originName} />
+          </SwiperSlide>
+        ))}
       </Swiper>
       <Swiper
         onSwiper={setThumbsSwiper}
@@ -69,13 +64,11 @@ const AlbumDeatilImage = () => {
         className="mySwiper2"
         initialSlide={activeSlider}
       >
-        {albumDatas?.pages
-          ?.flatMap((page: any) => page.data.content)
-          .map((album: Album) => (
-            <SwiperSlide key={album.image_Id}>
-              <img src={album.resizeUrl} alt={album.originName} />
-            </SwiperSlide>
-          ))}
+        {albumDetailData?.pages.map((album: any) => (
+          <SwiperSlide key={album.image_Id}>
+            <img src={album.resizeUrl} alt={album.originName} />
+          </SwiperSlide>
+        ))}
       </Swiper>
     </S.Container>
   );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,7 +2,7 @@ import { useAtomValue } from 'jotai';
 import HomeAlbum from '../../components/home/HomeAlbum';
 import NoneContent from '../../components/layout/NoneContent';
 import useInfinityAlbum from '../../hooks/useInfinityAlbum';
-import useIntersectionObserver from '../../hooks/useInfinityObserver';
+import useInfinityObserver from '../../hooks/useInfinityObserver';
 import { userStore } from '../../stores/userStore';
 
 const HomePage = () => {
@@ -10,7 +10,7 @@ const HomePage = () => {
 
   const { data: albumData, fetchNextPage, hasNextPage } = useInfinityAlbum(users?.accessToken ?? '');
 
-  const { setTarget } = useIntersectionObserver({
+  const { setTarget } = useInfinityObserver({
     hasNextPage,
     fetchNextPage,
   });


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약

- host_03 페이지 전체적으로 리팩토링 진행

## 🔎 작업 상세 설명

- 미니 앨범 영역 무한 스크롤 추가
    - 이에 따른 기존 캐싱된 쿼리 데이터에서 Hooks를 통한 데이터 가져오기
- 메세지 영역 ON/OFF 및 슬라이더 시 두번 클릭해야 되는 버그 수정
- 이미지 삭제시 하단 상세 이미지 정보 (날짜) 현재 슬라이더 정보로 갱신할 수 있도록 수정
- 일부 타입 추가

## 🌟 논의 사항

- 이미지 상세 페이지 내 Lazy Loading과 스켈레톤 UI가 필요할까? 고민이 필요할듯 싶습니다.