### PR TITLE
feat: 마이 페이지 전체 레이아웃 추가

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: 'https://momentpic.store',
+  baseURL: 'https://www.momentpic.store',
   headers: {
     'Content-Type': 'application/json;charset=UTF-8',
   },

--- a/src/api/mypage/index.ts
+++ b/src/api/mypage/index.ts
@@ -1,0 +1,15 @@
+import { HTTP_METHOD } from '../../constants/api';
+import { ROUTES_PATH } from '../../constants/routes';
+import instance from '../axios';
+
+export const USER_BOARD_COUNT = ['users', 'board-count'];
+
+export const getUserBoardCount = (accessToken: string) => {
+  return instance({
+    url: ROUTES_PATH.mypage,
+    method: HTTP_METHOD.GET,
+    headers: {
+      'X-AUTH-TOKEN': accessToken,
+    },
+  });
+};

--- a/src/components/common/Skeleton/ProfileCount.tsx
+++ b/src/components/common/Skeleton/ProfileCount.tsx
@@ -1,0 +1,52 @@
+import styled, { keyframes } from 'styled-components';
+
+const loading = keyframes`
+  0% {
+    transform: translateX(-50%);
+  }
+  50% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+const ProfileCount = () => {
+  return (
+    <>
+      <Container>
+        <CountText />
+        <CountTitleText> 메시지 </CountTitleText>
+      </Container>
+      <Container>
+        <CountText />
+        <CountTitleText> 이미지 </CountTitleText>
+      </Container>
+    </>
+  );
+};
+
+export default ProfileCount;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+
+  box-sizing: border-box;
+`;
+
+const CountText = styled.div`
+  width: 15px;
+  height: 15px;
+
+  background: linear-gradient(90deg, #f5f5f5 0%, #ffffffae 30%, #f5f5f5 60%);
+  animation: ${loading} 1.5s infinite linear;
+`;
+
+const CountTitleText = styled.span`
+  font-size: ${({ theme }) => theme.typography.body1.fontSize};
+  font-family: ${({ theme }) => theme.typography.body1.fontFamily};
+`;

--- a/src/components/common/Skeleton/index.ts
+++ b/src/components/common/Skeleton/index.ts
@@ -1,3 +1,4 @@
 import AlbumImage from './AlbumImage';
+import ProfileCount from './ProfileCount';
 
-export { AlbumImage };
+export { AlbumImage, ProfileCount };

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -27,7 +27,7 @@ const Header = () => {
   };
 
   return (
-    <Layout>
+    <Layout $current={validateCheckDetail(pathname)}>
       {validateCheckDetail(pathname) ? (
         <MoreWrapper>
           <BackButton onClick={handleBackUrl} />
@@ -36,7 +36,7 @@ const Header = () => {
       ) : (
         <UserWrapper to={ROUTES_PATH.mypage}>
           <UserTitle> {userInfo?.kakaoName ?? '김태웅'} 님 </UserTitle>
-          <RightButton $type="userInfo" />
+          {pathname !== ROUTES_PATH.mypage && <RightButton $type="userInfo" />}
         </UserWrapper>
       )}
     </Layout>
@@ -45,7 +45,7 @@ const Header = () => {
 
 export default Header;
 
-const Layout = styled.header`
+const Layout = styled.header<{ $current: boolean }>`
   position: sticky;
   top: 0;
   z-index: 10;
@@ -57,7 +57,7 @@ const Layout = styled.header`
   box-sizing: border-box;
   margin: 0 auto;
 
-  border-bottom: 1px solid ${({ theme }) => theme.colors.lightGray2};
+  border-bottom: 1px solid ${({ theme, $current }) => ($current ? theme.colors.lightGray2 : 'transparent')};
 `;
 
 const UserWrapper = styled(Link)`

--- a/src/components/mypage/CountCount.tsx
+++ b/src/components/mypage/CountCount.tsx
@@ -1,0 +1,27 @@
+import { useAtomValue } from 'jotai';
+import { useQuery } from '@tanstack/react-query';
+import * as S from './Profile.styled';
+
+import { USER_BOARD_COUNT, getUserBoardCount } from '../../api/mypage';
+
+import { userStore } from '../../stores/userStore';
+
+const ContentCount = () => {
+  const user = useAtomValue(userStore)!;
+  const { data: countData } = useQuery(USER_BOARD_COUNT, () => getUserBoardCount(user?.accessToken));
+
+  return (
+    <>
+      <S.ContnetCounterWrapper>
+        <S.CountText> {countData?.data.messageCount} </S.CountText>
+        <S.CountTitleText> 메시지 </S.CountTitleText>
+      </S.ContnetCounterWrapper>
+      <S.ContnetCounterWrapper>
+        <S.CountText> {countData?.data.imageCount} </S.CountText>
+        <S.CountTitleText> 이미지 </S.CountTitleText>
+      </S.ContnetCounterWrapper>
+    </>
+  );
+};
+
+export default ContentCount;

--- a/src/components/mypage/Profile.styled.ts
+++ b/src/components/mypage/Profile.styled.ts
@@ -10,6 +10,12 @@ export const Container = styled.div`
 
 export const ProfileWrapper = styled.div`
   display: flex;
+  align-items: center;
+  gap: 60px;
+
+  & > div {
+    flex-grow: 1;
+  }
 `;
 
 export const ProfileImage = styled.img`
@@ -17,4 +23,25 @@ export const ProfileImage = styled.img`
   height: 80px;
 
   border-radius: 50%;
+  box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.2);
+`;
+
+export const ContnetCounterWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+
+  box-sizing: border-box;
+`;
+
+export const CountText = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.point};
+  font-family: ${({ theme }) => theme.fonts.bold};
+`;
+
+export const CountTitleText = styled.span`
+  font-size: ${({ theme }) => theme.typography.body1.fontSize};
+  font-family: ${({ theme }) => theme.typography.body1.fontFamily};
 `;

--- a/src/components/mypage/Profile.styled.ts
+++ b/src/components/mypage/Profile.styled.ts
@@ -75,6 +75,7 @@ export const ProfileButton = styled.button`
 
   background-color: ${({ theme }) => theme.colors.point};
   color: ${({ theme }) => theme.colors.white};
+  box-shadow: 0px 4px 12px 0px rgba(146, 181, 217, 0.5);
 
   border-radius: 5px;
   cursor: pointer;
@@ -84,5 +85,39 @@ export const ProfileButton = styled.button`
     height: 40px;
 
     font-size: ${({ theme }) => theme.typography.subHead.fontSize};
+  }
+`;
+
+export const Menu = styled.ul`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  padding: 0;
+  padding-top: 60px;
+
+  box-sizing: border-box;
+`;
+
+export const MenuList = styled.li`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+
+  padding-bottom: 18px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightGray2};
+
+  cursor: pointer;
+`;
+
+export const ListContentText = styled.span`
+  font-size: 14px;
+  font-family: ${({ theme }) => theme.typography.body1.fontFamily};
+
+  ${MEDIA_QUERY.sm} {
+    font-size: ${({ theme }) => theme.typography.body1.fontSize};
   }
 `;

--- a/src/components/mypage/Profile.styled.ts
+++ b/src/components/mypage/Profile.styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { MEDIA_QUERY } from '../../constants/styles';
 
 export const Container = styled.div`
   width: 100%;
@@ -36,12 +37,52 @@ export const ContnetCounterWrapper = styled.div`
 `;
 
 export const CountText = styled.span`
-  font-size: 12px;
+  font-size: 14px;
   color: ${({ theme }) => theme.colors.point};
   font-family: ${({ theme }) => theme.fonts.bold};
+
+  ${MEDIA_QUERY.sm} {
+    font-size: 12px;
+  }
 `;
 
 export const CountTitleText = styled.span`
-  font-size: ${({ theme }) => theme.typography.body1.fontSize};
+  font-size: 14px;
   font-family: ${({ theme }) => theme.typography.body1.fontFamily};
+
+  ${MEDIA_QUERY.sm} {
+    font-size: ${({ theme }) => theme.typography.body1.fontSize};
+  }
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  gap: 15px;
+`;
+
+export const ProfileButton = styled.button`
+  all: unset;
+
+  width: 50%;
+  height: 50px;
+
+  font-size: 14px;
+  font-family: ${({ theme }) => theme.typography.subHead.fontFamily};
+  text-align: center;
+  line-height: 40px;
+
+  background-color: ${({ theme }) => theme.colors.point};
+  color: ${({ theme }) => theme.colors.white};
+
+  border-radius: 5px;
+  cursor: pointer;
+
+  ${MEDIA_QUERY.sm} {
+    width: 156px;
+    height: 40px;
+
+    font-size: ${({ theme }) => theme.typography.subHead.fontSize};
+  }
 `;

--- a/src/components/mypage/Profile.styled.ts
+++ b/src/components/mypage/Profile.styled.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`;
+
+export const ProfileWrapper = styled.div`
+  display: flex;
+`;
+
+export const ProfileImage = styled.img`
+  width: 80px;
+  height: 80px;
+
+  border-radius: 50%;
+`;

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -1,0 +1,18 @@
+import { useAtomValue } from 'jotai';
+import * as S from './Profile.styled';
+
+import { userStore } from '../../stores/userStore';
+
+const Profile = () => {
+  const user = useAtomValue(userStore)!;
+
+  return (
+    <S.Container>
+      <S.ProfileWrapper>
+        <S.ProfileImage src={user.profile_image} alt={`${user.kakaoName}_profile_image`} />
+      </S.ProfileWrapper>
+    </S.Container>
+  );
+};
+
+export default Profile;

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -10,6 +10,14 @@ const Profile = () => {
     <S.Container>
       <S.ProfileWrapper>
         <S.ProfileImage src={user.profile_image} alt={`${user.kakaoName}_profile_image`} />
+        <S.ContnetCounterWrapper>
+          <S.CountText> 0 </S.CountText>
+          <S.CountTitleText> 메시지 </S.CountTitleText>
+        </S.ContnetCounterWrapper>
+        <S.ContnetCounterWrapper>
+          <S.CountText> 0 </S.CountText>
+          <S.CountTitleText> 이미지 </S.CountTitleText>
+        </S.ContnetCounterWrapper>
       </S.ProfileWrapper>
     </S.Container>
   );

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -17,6 +17,10 @@ const Profile = () => {
           <ContentCount />
         </Suspense>
       </S.ProfileWrapper>
+      <S.ButtonWrapper>
+        <S.ProfileButton type="button"> 프로필 편집 </S.ProfileButton>
+        <S.ProfileButton type="button"> 앨범 공유 </S.ProfileButton>
+      </S.ButtonWrapper>
     </S.Container>
   );
 };

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -1,6 +1,9 @@
+import { Suspense } from 'react';
 import { useAtomValue } from 'jotai';
 import * as S from './Profile.styled';
 
+import ContentCount from './CountCount';
+import { ProfileCount } from '../common/Skeleton';
 import { userStore } from '../../stores/userStore';
 
 const Profile = () => {
@@ -10,14 +13,9 @@ const Profile = () => {
     <S.Container>
       <S.ProfileWrapper>
         <S.ProfileImage src={user.profile_image} alt={`${user.kakaoName}_profile_image`} />
-        <S.ContnetCounterWrapper>
-          <S.CountText> 0 </S.CountText>
-          <S.CountTitleText> 메시지 </S.CountTitleText>
-        </S.ContnetCounterWrapper>
-        <S.ContnetCounterWrapper>
-          <S.CountText> 0 </S.CountText>
-          <S.CountTitleText> 이미지 </S.CountTitleText>
-        </S.ContnetCounterWrapper>
+        <Suspense fallback={<ProfileCount />}>
+          <ContentCount />
+        </Suspense>
       </S.ProfileWrapper>
     </S.Container>
   );

--- a/src/components/mypage/UserMenu.tsx
+++ b/src/components/mypage/UserMenu.tsx
@@ -1,0 +1,20 @@
+import * as S from './Profile.styled';
+
+import RightIcon from '../../assets/icons/RightIcon';
+
+const UserMenu = () => {
+  return (
+    <S.Menu>
+      <S.MenuList>
+        <S.ListContentText> moment 이벤트 </S.ListContentText>
+        <RightIcon $type="message" />
+      </S.MenuList>
+      <S.MenuList>
+        <S.ListContentText> 로그아웃 </S.ListContentText>
+        <RightIcon $type="message" />
+      </S.MenuList>
+    </S.Menu>
+  );
+};
+
+export default UserMenu;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,7 +4,6 @@ export const ROUTES_PATH = {
   redirect: '/login/oauth2/callback/kakao',
   message: '/message',
   messageDetail: '/message/details/:id',
-  // messageDetail: '/message/details',
   mypage: '/mypage',
   albumDetail: '/album/details',
 } as const;

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,3 +1,4 @@
+import { ROUTES_PATH } from './routes';
 import albumIcon from '../assets/icons/AlbumIcon';
 import messageIcon from '../assets/icons/MessageIcon';
 import myPageIcon from '../assets/icons/MyPageIcon';
@@ -38,19 +39,19 @@ export const FOOTER_MENUS = [
   {
     id: 1,
     name: '앨범',
-    path: '/',
+    path: ROUTES_PATH.main,
     icon: albumIcon,
   },
   {
     id: 2,
     name: '메시지',
-    path: '/message',
+    path: ROUTES_PATH.message,
     icon: messageIcon,
   },
   {
     id: 3,
     name: '마이',
-    path: '/mypage',
+    path: ROUTES_PATH.mypage,
     icon: myPageIcon,
   },
 ] as const;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import Profile from '../../components/mypage/Profile';
+
+const MyPage = () => {
+  return (
+    <Layout>
+      <Profile />
+    </Layout>
+  );
+};
+
+export default MyPage;
+
+const Layout = styled.section`
+  padding: 0 24px;
+
+  box-sizing: border-box;
+`;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 import Profile from '../../components/mypage/Profile';
+import UserMenu from '../../components/mypage/UserMenu';
 
 const MyPage = () => {
   return (
     <Layout>
       <Profile />
+      <UserMenu />
     </Layout>
   );
 };

--- a/src/provider/LayoutProvider.tsx
+++ b/src/provider/LayoutProvider.tsx
@@ -37,10 +37,14 @@ const Layout = styled.section`
   flex-direction: column;
 
   background-color: rgb(245, 245, 245);
+
+  box-sizing: border-box;
 `;
 
 const Container = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  box-sizing: border-box;
 `;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,11 +4,12 @@ import App from '../App';
 import AuthRedirection from '../pages/AuthRedirection';
 import HomePage from '../pages/Home';
 import LoginPage from '../pages/Login';
+import MessageDetail from '../pages/MessageDetail';
+import Messages from '../pages/Messages';
+import MyPage from '../pages/MyPage';
 import { ROUTES_PATH } from '../constants/routes';
 import TestPage from '../pages/Test';
 import { withAuth } from '../hoc/withAuth';
-import Messages from '../pages/Messages';
-import MessageDetail from '../pages/MessageDetail';
 
 const router = createBrowserRouter([
   {
@@ -30,6 +31,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES_PATH.messageDetail,
         Component: withAuth(MessageDetail),
+      },
+      {
+        path: ROUTES_PATH.mypage,
+        Component: withAuth(MyPage),
       },
       {
         path: ROUTES_PATH.login,


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약

- 마이 페이지 레이아웃 추가

## 🔎 작업 상세 설명

- 마이 페이지 레이아웃 추가
- 마이 페이지 내 이미지, 메세지 수 스켈레톤 UI 추가
- 헤더 내 스타일 로직 추가

## 🌟 논의 사항

- 버튼이 전체적으로 공통적으로 색상 및 가로, 높이 값만 받도록 해서 `common`에 버튼 컴포넌트 따로 만들 수 있을 것 같은데, 어떻게 생각하시나요?
