### PR TITLE
feat: 게스트 이미지 업로드 및 조건부 라우팅 일부 수정

### DIFF
--- a/src/components/guest/GuestFileUpload.tsx
+++ b/src/components/guest/GuestFileUpload.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useSetAtom } from 'jotai';
-import { guestFileStore } from '../../stores/guestFileStore';
+import { guestFileStore } from '../../stores/guestStore';
 import { ROUTES_PATH } from '../../constants/routes';
 
 const GuestFileUpload = () => {

--- a/src/components/guest/GuestFileUpload.tsx
+++ b/src/components/guest/GuestFileUpload.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import { useSetAtom } from 'jotai';
 import { guestFileStore } from '../../stores/guestFileStore';
+import { ROUTES_PATH } from '../../constants/routes';
 
 const GuestFileUpload = () => {
+  const navigate = useNavigate();
   const setGuestFileList = useSetAtom(guestFileStore);
 
   const handleUploadImageFiles = async (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -14,6 +17,7 @@ const GuestFileUpload = () => {
 
     if (files) {
       setGuestFileList(files);
+      navigate(ROUTES_PATH.guestEdit);
     }
   };
 

--- a/src/components/guest/GuestFileUpload.tsx
+++ b/src/components/guest/GuestFileUpload.tsx
@@ -1,11 +1,19 @@
 import styled from 'styled-components';
+import { useSetAtom } from 'jotai';
+import { guestFileStore } from '../../stores/guestFileStore';
 
 const GuestFileUpload = () => {
+  const setGuestFileList = useSetAtom(guestFileStore);
+
   const handleUploadImageFiles = async (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = evt.target;
 
     if (files && files?.length > 5) {
       alert('최대 5개의 이미지만 업로드 할 수 있습니다. 다시 한 번 확인해주세요. ');
+    }
+
+    if (files) {
+      setGuestFileList(files);
     }
   };
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,4 +8,5 @@ export const ROUTES_PATH = {
   albumDetail: '/album/details',
   event: '/event',
   guest: '/guest',
+  guestEdit: '/guest/edit',
 } as const;

--- a/src/pages/Guest.tsx
+++ b/src/pages/Guest.tsx
@@ -1,15 +1,22 @@
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
 import { HOST_USER_KEY, getHostInformation } from '../api/guest';
 
 import GuestFileUpload from '../components/guest/GuestFileUpload';
 import GuestLogo from '../assets/images/guestMoment.png';
+import { guestAuthStore } from '../stores/guestStore';
 
 const GuestPage = () => {
+  const setGuestAuth = useSetAtom(guestAuthStore);
   const params = new URL(document.location.toString()).searchParams;
   const code = params.get('host');
 
-  const { data: hostInformation } = useQuery(HOST_USER_KEY, () => getHostInformation(code!));
+  const { data: hostInformation } = useQuery(HOST_USER_KEY, () => getHostInformation(code!), {
+    onSuccess: (res) => {
+      setGuestAuth(res.data);
+    },
+  });
 
   return (
     <Layout>

--- a/src/pages/GuestEdit.tsx
+++ b/src/pages/GuestEdit.tsx
@@ -1,0 +1,5 @@
+const GuestEditPage = () => {
+  return <div> 게스트 수정 페이지 </div>;
+};
+
+export default GuestEditPage;

--- a/src/provider/LayoutProvider.tsx
+++ b/src/provider/LayoutProvider.tsx
@@ -16,7 +16,7 @@ const LayoutProvider = ({ children }: Props) => {
   return (
     <Layout>
       <Container>
-        {pathname === ROUTES_PATH.login || pathname === ROUTES_PATH.guest ? (
+        {pathname === ROUTES_PATH.login || pathname.includes(ROUTES_PATH.guest) ? (
           children
         ) : (
           <MomentBody>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,7 @@ import AlbumPage from '../pages/Album';
 import App from '../App';
 import Auth from '../pages/Auth';
 import EventPage from '../pages/Event';
+import GuestEditPage from '../pages/GuestEdit';
 import GuestPage from '../pages/Guest';
 import LocalErrorBoundary from '../components/common/Errors/LocalErrorBoundary';
 import LoginPage from '../pages/Login';
@@ -48,11 +49,20 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTES_PATH.guest,
-        element: (
-          <LocalErrorBoundary>
-            <GuestPage />
-          </LocalErrorBoundary>
-        ),
+        children: [
+          {
+            index: true,
+            element: (
+              <LocalErrorBoundary>
+                <GuestPage />
+              </LocalErrorBoundary>
+            ),
+          },
+          {
+            path: ROUTES_PATH.guestEdit,
+            element: <GuestEditPage />,
+          },
+        ],
       },
     ],
   },

--- a/src/stores/guestFileStore.ts
+++ b/src/stores/guestFileStore.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const guestFileStore = atom<FileList | null>(null);

--- a/src/stores/guestFileStore.ts
+++ b/src/stores/guestFileStore.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const guestFileStore = atom<FileList | null>(null);

--- a/src/stores/guestStore.ts
+++ b/src/stores/guestStore.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai';
+import type { Guest } from '../types/user';
+
+export const guestFileStore = atom<FileList | null>(null);
+
+export const guestAuthStore = atom<Guest | null>(null);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -15,3 +15,5 @@ export type User = AuthToken & {
   kakaoName: string;
   profile_image: string;
 };
+
+export type Guest = Pick<User, 'accessToken' | 'accessTokenExpireDate' | 'issuedAt' | 'kakaoName' | 'profile_image'>;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #68 

## 📝 작업 요약

- 게스트 이미지 업로드 및 조건부 라우팅 일부 수정

## 🔎 작업 상세 설명

- `LayoutProvider.tsx` 내 게스트 페이지 여부에 따른 조건부 로직 수정
- 게스트 이미지 업로드를 위한 전역 상태 내 `guestFIleStore.ts` 스토어 추가
- 게스트 정보 저장을 위한 스토어 추가

## 🌟 논의 사항

팀원들과 이야기 해보고 싶은 부분을 적어주세요.
